### PR TITLE
new API not compatible for mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ make       # makes both!
 OpenCL is installed on OS X by default, but since this code uses the C++ bindings, you'll need to get that too. Get the [official C++ bindings from the OpenCL registr](https://www.khronos.org/registry/cl/api/1.1/cl.hpp) and copy it to the OpenCL framework directory, or do the following:
 
 ```
-wget https://www.khronos.org/registry/cl/api/1.1/cl.hpp
-sudo cp cl.hpp /System/Library/Frameworks/OpenCL.framework/Headers/
+wget https://www.khronos.org/registry/OpenCL/api/2.1/cl.hpp
+sudo cp cl.hpp /path/to/the/examples/folder/
 ```
 
 To compile:


### PR DESCRIPTION
trying the `wget https://www.khronos.org/registry/cl/api/1.1/cl.hpp` fails: 

> 301 Moved Permanently
Location: https://www.khronos.org/registry/OpenCL/api/1.1/cl.hpp [following]
--2018-05-12 04:14:56--  https://www.khronos.org/registry/OpenCL/api/1.1/cl.hpp
Connecting to www.khronos.org (www.khronos.org)|104.236.24.254|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2018-05-12 04:14:56 ERROR 404: Not Found.
 and the `sudo cp cl.hpp /System/Library/Frameworks/OpenCL.framework/Headers/` also fails 

> cp: /System/Library/Frameworks/OpenCL.framework/Headers/cl.hpp: Operation not permitted

instead the cl.hpp should be copied to a local folder